### PR TITLE
Add multi-platform Docker build support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,10 +41,17 @@ jobs:
             type=sha,prefix={{branch}}-
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Added multi-platform build support for Docker images
- Fixes platform mismatch warnings on ARM64 hosts

## Changes
- Added QEMU setup for cross-platform emulation
- Added Docker Buildx setup for multi-platform builds
- Configured build to create images for both linux/amd64 and linux/arm64

## Test plan
- [ ] GitHub Actions workflow runs successfully
- [ ] Images work on both AMD64 and ARM64 platforms without warnings

Co-Authored-By: Claude <noreply@anthropic.com>