### PR TITLE
Fix README: Correct Docker registry reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## 使い方
 
-### Docker Hub から実行
+### GitHub Container Registry から実行
 
 ```bash
 # デフォルトポート（9876）で実行


### PR DESCRIPTION
## Summary
- Fixed incorrect reference to Docker Hub in README
- This project uses GitHub Container Registry (ghcr.io), not Docker Hub

## Changes
- Changed "Docker Hub から実行" to "GitHub Container Registry から実行"

Co-Authored-By: Claude <noreply@anthropic.com>