### PR TITLE
Add access logs endpoint

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,7 +38,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up QEMU

--- a/server.py
+++ b/server.py
@@ -6,15 +6,37 @@ import socket
 import json
 import sys
 from datetime import datetime
+from collections import deque
+import threading
+
+# Global access log storage (thread-safe)
+access_logs = deque(maxlen=100)
+access_logs_lock = threading.Lock()
 
 class DebugHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
+        # Log access for all requests
+        self.log_access()
+        
         # Handle /ping endpoint
         if self.path == '/ping':
             self.send_response(200)
             self.send_header('Content-type', 'text/plain')
             self.end_headers()
             self.wfile.write(b'pong')
+            return
+        
+        # Handle /logs endpoint
+        if self.path == '/logs':
+            self.send_response(200)
+            self.send_header('Content-type', 'application/json')
+            self.end_headers()
+            
+            with access_logs_lock:
+                logs = list(access_logs)
+            
+            response = json.dumps(logs, indent=2, ensure_ascii=False)
+            self.wfile.write(response.encode('utf-8'))
             return
         
         # Default handler for all other paths
@@ -42,6 +64,38 @@ class DebugHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         
         response = json.dumps(debug_info, indent=2, ensure_ascii=False)
         self.wfile.write(response.encode('utf-8'))
+    
+    def do_POST(self):
+        self.log_access()
+        self.send_error(405, "Method Not Allowed")
+    
+    def do_PUT(self):
+        self.log_access()
+        self.send_error(405, "Method Not Allowed")
+    
+    def do_DELETE(self):
+        self.log_access()
+        self.send_error(405, "Method Not Allowed")
+    
+    def do_HEAD(self):
+        self.log_access()
+        self.send_error(405, "Method Not Allowed")
+    
+    def log_access(self):
+        """Log access information"""
+        log_entry = {
+            "timestamp": datetime.now().isoformat(),
+            "method": self.command,
+            "path": self.path,
+            "client_address": self.client_address[0],
+            "client_port": self.client_address[1],
+            "user_agent": self.headers.get('User-Agent', ''),
+            "referer": self.headers.get('Referer', ''),
+            "host": self.headers.get('Host', '')
+        }
+        
+        with access_logs_lock:
+            access_logs.append(log_entry)
     
     def get_ip_addresses(self):
         """Get all IP addresses of the host"""

--- a/server.py
+++ b/server.py
@@ -9,6 +9,15 @@ from datetime import datetime
 
 class DebugHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
+        # Handle /ping endpoint
+        if self.path == '/ping':
+            self.send_response(200)
+            self.send_header('Content-type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'pong')
+            return
+        
+        # Default handler for all other paths
         self.send_response(200)
         self.send_header('Content-type', 'application/json')
         self.end_headers()


### PR DESCRIPTION
## Summary
- Added `/logs` endpoint that returns the most recent 100 access logs
- Useful for debugging and monitoring access patterns

## Features
- Returns up to 100 most recent access logs in JSON format
- Thread-safe implementation using `deque` and `threading.Lock`
- Logs all HTTP methods (GET, POST, PUT, DELETE, HEAD)
- Each log entry includes:
  - timestamp
  - HTTP method
  - request path
  - client address and port
  - user-agent
  - referer
  - host header

## Example Response
```json
[
  {
    "timestamp": "2025-08-01T10:53:56.805659",
    "method": "GET",
    "path": "/test1",
    "client_address": "127.0.0.1",
    "client_port": 52190,
    "user_agent": "curl/8.7.1",
    "referer": "",
    "host": "localhost:8878"
  },
  {
    "timestamp": "2025-08-01T10:53:56.877205",
    "method": "GET",
    "path": "/ping",
    "client_address": "127.0.0.1",
    "client_port": 52192,
    "user_agent": "curl/8.7.1",
    "referer": "",
    "host": "localhost:8878"
  }
]
```

## Test
```bash
# Start server
docker run -p 9876:9876 debug-httpd:latest

# Make some requests
curl http://localhost:9876/
curl http://localhost:9876/ping
curl http://localhost:9876/test

# View access logs
curl http://localhost:9876/logs | jq .
```

Co-Authored-By: Claude <noreply@anthropic.com>